### PR TITLE
[fix] refs #82 collage機能後にrefetchして最新の回答にするように修正

### DIFF
--- a/src/src/components/organisms/Impressions.vue
+++ b/src/src/components/organisms/Impressions.vue
@@ -30,29 +30,13 @@
 
 <script lang="ts">
 import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
-import gql from 'graphql-tag';
 import ProfileRoundImage from '../atoms/ProfileRoundImage.vue';
 import NoImpressionCard from '../molecules/NoImpressionCard.vue';
 import ModalForm from '../organisms/ModalForm.vue';
 import ReactionIconGroup from '../molecules/ReactionIconGroup.vue';
+import { impressionQuery } from '../../constants/get-user-impression-query';
 
 const pageSize: any = 10;
-const impressionQuery: any = gql`
-query getUserImpressions($name: String, $page: Int, $size: Int){
-  userImpressions(username: $name, page: $page, size: $size){
-    id
-    content
-    question{
-      id
-      about
-      appearedAt
-      category{
-        id
-        name
-      }
-    }
-  }
-}`;
 
 @Component({
   components: {
@@ -139,6 +123,10 @@ export default class Impressions extends Vue {
   @Emit()
   public toggleImpressionModal() {
     this.showImpressionModal = false;
+    this.$apollo.queries.userImpressions.setVariables(
+      { name: this.$route.params.userName, page: 0, size: pageSize },
+    );
+    this.$apollo.queries.userImpressions.refetch();
   }
 
   @Emit()

--- a/src/src/components/organisms/ModalForm.vue
+++ b/src/src/components/organisms/ModalForm.vue
@@ -27,6 +27,7 @@ import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
 import ConfirmButton from '../atoms/ConfirmButton.vue';
 import router from '../../router';
 import { CreateImpressionMutation } from '../../constants/create_impression_query';
+import { impressionQuery } from '../../constants/get-user-impression-query';
 
 @Component({
   components: {
@@ -49,7 +50,7 @@ export default class ModalForm extends Vue {
   private showImpressionModal!: boolean;
 
   @Emit()
-  public postMutation(isCollage: boolean) {
+  private postMutation(isCollage: boolean) {
     const mutation = this.$apollo.mutate({
       mutation: CreateImpressionMutation,
       variables: {
@@ -57,14 +58,15 @@ export default class ModalForm extends Vue {
         userName:  this.$route.params.userName,
         questionId: this.selectedQuestionId,
       },
-      fetchPolicy: 'no-cache',
-      // TODO: updateを追加してmutation後にprofile画面に遷移したときにimpressionを更新するようにする
-      // refs: https://learn.hasura.io/graphql/vue/optimistic-update-mutations/2-mutation-cache
     });
 
     mutation
-      .then(({ data: { result } }) => {
-        return result;
+      .then(({ data }) => {
+        if (!data) {
+          throw new Error('data is undefined');
+        }
+        const res = data.createImpression;
+        return res;
       })
       .then(({ ok, impression, errors }) => {
         if (ok) {

--- a/src/src/constants/create_impression_query.ts
+++ b/src/src/constants/create_impression_query.ts
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
 
 export const CreateImpressionMutation = gql`
-mutation ($content: String!, $userName: String!, $questionId: Int!) {
-  result: createImpression(content: $content, username: $userName, questionId: $questionId,){
+mutation createImpression($content: String!, $userName: String!, $questionId: Int!) {
+  createImpression(content: $content, username: $userName, questionId: $questionId,){
       ok
       impression{
         id

--- a/src/src/constants/get-user-impression-query.ts
+++ b/src/src/constants/get-user-impression-query.ts
@@ -1,0 +1,18 @@
+import gql from 'graphql-tag';
+
+export const impressionQuery: any = gql`
+query getUserImpressions($name: String, $page: Int, $size: Int){
+  userImpressions(username: $name, page: $page, size: $size){
+    id
+    content
+    question{
+      id
+      about
+      appearedAt
+      category{
+        id
+        name
+      }
+    }
+  }
+}`;


### PR DESCRIPTION
## 関連Issue
#82 

## 変更点
- [x] 投稿後に `this.$apollo.userImpressions.refetch()` を発動させてクエリを再取得する
- [x] リファクタリングした