### PR TITLE
refs #76 ヘッダーのログインボタンの処理を追加

### DIFF
--- a/src/src/App.vue
+++ b/src/src/App.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   div(id="app" class='wrapper')
-    Header
+    Header(:login="login")
     router-view
     li
       router-link(to='/') Home

--- a/src/src/App.vue
+++ b/src/src/App.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   div(id="app" class='wrapper')
-    Header(:login="login")
+    Header(v-on:login="login")
     router-view
     li
       router-link(to='/') Home

--- a/src/src/components/organisms/Header.vue
+++ b/src/src/components/organisms/Header.vue
@@ -6,11 +6,11 @@ sui-container.header-container
         router-link.header-link(to='/')
           img(src='@/assets/icon.svg')
       .right-wrapper
-        SubButton(label='ログイン・登録')
+        SubButton(label='ログイン・登録' @click.native="login" v-if="this.$parent.isAuthenticated == false")
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Vue, Prop } from 'vue-property-decorator';
 import SubButton from '../atoms/SubButton.vue';
 
 @Component({
@@ -18,7 +18,9 @@ import SubButton from '../atoms/SubButton.vue';
     SubButton,
   },
 })
-export default class Header extends Vue {}
+export default class Header extends Vue {
+  @Prop({type: Function}) login: Function;
+}
 </script>
 
 <style lang="stylus" scoped>

--- a/src/src/components/organisms/Header.vue
+++ b/src/src/components/organisms/Header.vue
@@ -10,7 +10,7 @@ sui-container.header-container
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Component, Vue} from 'vue-property-decorator';
 import SubButton from '../atoms/SubButton.vue';
 
 @Component({

--- a/src/src/components/organisms/Header.vue
+++ b/src/src/components/organisms/Header.vue
@@ -10,7 +10,7 @@ sui-container.header-container
 </template>
 
 <script lang="ts">
-import { Component, Vue} from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import SubButton from '../atoms/SubButton.vue';
 
 @Component({

--- a/src/src/components/organisms/Header.vue
+++ b/src/src/components/organisms/Header.vue
@@ -6,7 +6,7 @@ sui-container.header-container
         router-link.header-link(to='/')
           img(src='@/assets/icon.svg')
       .right-wrapper
-        SubButton(label='ログイン・登録' @click.native="login" v-if="this.$parent.isAuthenticated == false")
+        SubButton(label='ログイン・登録' @click.native="$emit('login')" v-if="this.$parent.isAuthenticated == false")
 </template>
 
 <script lang="ts">
@@ -18,9 +18,7 @@ import SubButton from '../atoms/SubButton.vue';
     SubButton,
   },
 })
-export default class Header extends Vue {
-  @Prop({type: Function}) login: Function;
-}
+export default class Header extends Vue {}
 </script>
 
 <style lang="stylus" scoped>


### PR DESCRIPTION
## 関連Issue

* https://github.com/Montages-Team/MontageClient/issues/76

## 変更点

- [x] ヘッダのログインボタンを `isAuthencticated=False` のときのみ表示するようにした
- [x] ヘッダのログインボタンにAuth0へのリンクを追加した

## レビューポイント

- [ ] 親子コンポーネントのデータのやりとりで、GoodかNGな表現があるかどうか
- [ ] 要件満たしてるよね？

## 注意点
- あれば書く


## reviewee チェックシート
- [x] 参考になる情報をチケット or PR に書くか、リンクした
- [x] セルフレビューを実施した(flake8)
- [x] カンバンを動かす
