### PR TITLE
[fix] refs #102 スマホ用設定ページの作成と遷移後の各コンポーネントの雛形を作成

### DIFF
--- a/src/src/App.vue
+++ b/src/src/App.vue
@@ -4,7 +4,7 @@
     router-view
     li(v-if='isAuthenticated' v-show="pathName !== 'home'")
       a(href='#', @click.prevent='logout') Log out
-    Footer
+    Footer(v-show="pathName !== 'settings'")
 </template>
 
 <script>

--- a/src/src/components/molecules/SettingsMenu.vue
+++ b/src/src/components/molecules/SettingsMenu.vue
@@ -1,0 +1,25 @@
+<template lang='pug'>
+    div
+      sui-accordion(exclusive=true, styled=true fluid=true)
+        router-link(to="/account")
+          sui-accordion-title.settings-menu プロフィールを編集
+        router-link(to="/change_password")
+          sui-accordion-title.settings-menu パスワードの変更
+        router-link(to="/change_mail")
+          sui-accordion-title.settings-menu メールアドレスの変更
+        router-link(to="/deactivate")
+          sui-accordion-title.settings-menu 退会
+</template>
+
+<script lang='ts'>
+import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
+
+@Component({})
+export default class SettingsMenu extends Vue {
+}
+</script>
+
+<style lang='stylus' scoped>
+.settings-menu
+  padding 16px !important
+</style>

--- a/src/src/components/organisms/AccountSettings.vue
+++ b/src/src/components/organisms/AccountSettings.vue
@@ -1,0 +1,14 @@
+<template lang='pug'>
+    div
+</template>
+
+<script lang='ts'>
+import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
+
+@Component({})
+export default class AccountSettings extends Vue {
+}
+</script>
+
+<style lang='stylus' scoped>
+</style>

--- a/src/src/components/organisms/ChangeMailForm.vue
+++ b/src/src/components/organisms/ChangeMailForm.vue
@@ -1,0 +1,14 @@
+<template lang='pug'>
+    div
+</template>
+
+<script lang='ts'>
+import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
+
+@Component({})
+export default class ChangeMailForm extends Vue {
+}
+</script>
+
+<style lang='stylus' scoped>
+</style>

--- a/src/src/components/organisms/ChangePasswordForm.vue
+++ b/src/src/components/organisms/ChangePasswordForm.vue
@@ -1,0 +1,14 @@
+<template lang='pug'>
+    div
+</template>
+
+<script lang='ts'>
+import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
+
+@Component({})
+export default class ChangePasswordForm extends Vue {
+}
+</script>
+
+<style lang='stylus' scoped>
+</style>

--- a/src/src/components/organisms/DeactivateForm.vue
+++ b/src/src/components/organisms/DeactivateForm.vue
@@ -1,0 +1,14 @@
+<template lang='pug'>
+    div
+</template>
+
+<script lang='ts'>
+import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
+
+@Component({})
+export default class DeactivateForm extends Vue {
+}
+</script>
+
+<style lang='stylus' scoped>
+</style>

--- a/src/src/router.ts
+++ b/src/src/router.ts
@@ -6,6 +6,11 @@ import Profile from './components/pages/Profile.vue';
 import Impressions from './components/organisms/Impressions.vue';
 import Questions from './components/organisms/Questions.vue';
 import Terms from './components/organisms/Terms.vue';
+import SettingsMenu from './components/molecules/SettingsMenu.vue';
+import AccountSettings from './components/organisms/AccountSettings.vue';
+import ChangePasswordForm from './components/organisms/ChangePasswordForm.vue';
+import ChangeMailForm from './components/organisms/ChangeMailForm.vue';
+import DeactivateForm from './components/organisms/DeactivateForm.vue';
 import Privacy from './components/organisms/Privacy.vue';
 import Faq from './components/organisms/Faq.vue';
 import auth from './auth/authService';
@@ -21,6 +26,31 @@ const router = new Router({
       path: '/',
       name: 'home',
       component: Home,
+    },
+    {
+      path: '/settings',
+      name: 'settings',
+      component: SettingsMenu,
+    },
+    {
+      path: '/account',
+      name: 'account',
+      component: AccountSettings,
+    },
+    {
+      path: '/change_password',
+      name: 'change_password',
+      component: ChangePasswordForm,
+    },
+    {
+      path: '/change_mail',
+      name: 'change_mail',
+      component: ChangeMailForm,
+    },
+    {
+      path: '/deactivate',
+      name: 'deactivate',
+      component: DeactivateForm,
     },
     {
       path: '/terms',


### PR DESCRIPTION
## 関連Issue
#102 

## 変更点
- [x] アコーディオンメニューを作成
- [x] router.tsに設定の各種ページへのリンクを追加
- [x] 各コンポーネントの雛形を作成

## reviewee チェックシート
- [x] 参考になる情報をチケット or PR に書くか、リンクした
- [x] セルフレビューを実施した(flake8)
- [x] カンバンを動かす
