### PR TITLE
【WIP】 プロフィール編集ページ＆アカウント削除ページの追加

### DIFF
--- a/src/src/App.vue
+++ b/src/src/App.vue
@@ -2,9 +2,10 @@
   div(id="app" class='wrapper')
     Header(v-show="pathName !== 'home'" v-on:login="login")
     router-view
+    router-view(name="settings" :userEmail="profile.email" :displayName="profile.name")
     li(v-if='isAuthenticated' v-show="pathName !== 'home'")
       a(href='#', @click.prevent='logout') Log out
-    Footer(v-show="pathName !== 'settings'")
+    Footer(v-if="displayFooter")
 </template>
 
 <script>
@@ -23,9 +24,18 @@ export default {
       isAuthenticated: false,
       profile: this.$auth.profile,
       pathName: this.$route.name,
+      displayFooter: null,
     };
   },
-
+  mounted() {
+    if (this.$route.name === 'settings' || this.$route.name === 'account' || this.$route.name === 'deactivate') {
+      this.displayFooter = false;
+      return this.displayFooter;
+    } else {
+      this.displayFooter = true;
+      return this.displayFooter;
+    }
+  },
   async created() {
     try {
       await this.$auth.renewTokens();

--- a/src/src/components/organisms/AccountSettings.vue
+++ b/src/src/components/organisms/AccountSettings.vue
@@ -1,5 +1,28 @@
 <template lang='pug'>
     div
+      sui-segment(style="padding-top: 30px")
+        div(is="sui-container" style="display: flex;")
+          sui-image(v-if="false" :src="userPicture", size='small', circular)
+          sui-image(v-else="true" src='https://semantic-ui-vue.github.io/static/images/avatar/large/kristy.png', size='small', circular)
+          a.upload-link(href="" @click="") 写真のアップロード
+          //- TODO: 写真をプロフィールから取得できるようにする
+          //- TODO: 写真アップロード処理
+        sui-form.account-form-margin
+          sui-form-field
+            label プロフィール名
+            input.disable-input(:value="displayName" disabled)
+          sui-button.username-button.change-button(size="tiny" compact type='submit' disabled content="保存")
+          //- sui-form-field
+          //-   label ユーザー名
+          //-   input.disable-input(:value="displayName" disabled)
+          //-   sui-list
+          //-     sui-list-item.input-status-info ユーザー名は変更できません
+          //- TODO ユーザ名を取得する
+          sui-form-field
+            label Email
+            input.disable-input(:value="userEmail" disabled)
+            sui-list-item.input-status-info 重要なおしらせは, 上記のEmailへ送られます
+          //- sui-button.label-button.change-button(compact type='submit' content="メールアドレスの変更")
 </template>
 
 <script lang='ts'>
@@ -7,8 +30,49 @@ import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
 
 @Component({})
 export default class AccountSettings extends Vue {
+  @Prop({type: String})
+  private userEmail!: string;
+
+  @Prop({type: String})
+  private displayName!: string;
+
+  @Prop({type: String})
+  private userPicture!: string;
 }
 </script>
 
 <style lang='stylus' scoped>
+.upload-link
+  height 20px
+  line-height 20px
+  margin 20% 25px
+
+.account-form-margin
+  margin 16px 0px
+
+.change-button
+  font-size 13px !important
+  display block !important
+  margin-left auto !important
+
+input.disable-input
+  background #F8F8F8 !important
+  border 1px solid #CCCCCC !important
+
+input.disable-input::placeholder
+  color #333333
+
+.input-status-info
+  color #8c8c8c !important
+  font-size 12px
+  margin auto 4px !important
+
+.label-button
+  color #b464a3 !important
+  background unset !important
+
+.username-button
+  color #fff !important
+  background #B464A3 !important
+
 </style>

--- a/src/src/components/organisms/DeactivateForm.vue
+++ b/src/src/components/organisms/DeactivateForm.vue
@@ -1,14 +1,62 @@
 <template lang='pug'>
     div
+      div(is="sui-container" style="padding-top: 30px")
+        h2(is='sui-header') アカウントを削除した場合:
+        sui-list(inverted)
+          sui-list-item.list-items(v-for="item in listItems" :key="item.id") {{item}}
+        sui-divider(inverted=true)
+        h5(style="margin: 8px;") 削除しようとしています。以下の「続ける」ボタンをタップしてください。
+        Button.justify(content='続ける' @click.native='toggleOpen')
+        sui-modal(v-model='open')
+          sui-modal-header 確認
+            p.modal-message アカウントを削除しようとしています。本当に続けますか？
+          sui-modal-actions
+            sui-button.modal-button-color(@click="") OK
+            //- TODO: アカウント削除処理
 </template>
 
 <script lang='ts'>
 import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
+import Button from '../atoms/Button.vue';
 
-@Component({})
+@Component({
+  components: {
+    Button,
+  },
+})
 export default class DeactivateForm extends Vue {
+  private listItems: string[] = [
+    '今後、そのアカウントからはmontageにログインできなくなります',
+    'プロフィールページが閲覧できなくなります。',
+    '自分以外のアカウントに対して投稿した回答は削除されません。',
+    'アカウントが無効化されている間、montageにサインインして自分のアカウントを回復することができます。',
+    'あなたのアカウントは30日感無効化されます。無効化中のアカウントは公開されません。30日を経過するとアカウントは完全に削除されます。',
+  ];
+  private open: boolean = false;
+
+  @Emit()
+  private toggleOpen() {
+    this.open = !this.open;
+  }
 }
 </script>
 
 <style lang='stylus' scoped>
+.justify
+  display block !important
+  margin 16px auto !important
+
+.list-items
+  font-size 15px !important
+  color #333
+  margin 8px
+  padding 4px 0
+
+.modal-message
+  font-size 15px
+  margin 16px
+
+.modal-button-color
+  background #B464A3 !important
+  color #fff !important
 </style>

--- a/src/src/components/pages/Home.vue
+++ b/src/src/components/pages/Home.vue
@@ -14,14 +14,12 @@
 <script lang='ts'>
 import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
 import DimButton from '../atoms/DimButton.vue';
-import Footer from '../organisms/Footer.vue';
 import FeatureColumnGroup from '../organisms/FeatureColumnGroup.vue';
 
 @Component({
   components: {
     DimButton,
     FeatureColumnGroup,
-    Footer,
   },
 })
 export default class Home extends Vue {}

--- a/src/src/router.ts
+++ b/src/src/router.ts
@@ -42,12 +42,16 @@ const router = new Router({
     {
       path: '/change_password',
       name: 'change_password',
-      component: ChangePasswordForm,
+      components: {
+        settings: ChangePasswordForm,
+      },
     },
     {
       path: '/change_mail',
       name: 'change_mail',
-      component: ChangeMailForm,
+      components: {
+        settings: ChangeMailForm,
+      },
     },
     {
       path: '/deactivate',

--- a/src/src/router.ts
+++ b/src/src/router.ts
@@ -52,7 +52,9 @@ const router = new Router({
     {
       path: '/deactivate',
       name: 'deactivate',
-      component: DeactivateForm,
+      components: {
+        settings: DeactivateForm,
+      },
     },
     {
       path: '/terms',

--- a/src/src/router.ts
+++ b/src/src/router.ts
@@ -35,7 +35,9 @@ const router = new Router({
     {
       path: '/account',
       name: 'account',
-      component: AccountSettings,
+      components: {
+        settings: AccountSettings,
+      },
     },
     {
       path: '/change_password',


### PR DESCRIPTION
## 関連Issue
#106 #107 

## 変更点
- [Add] refs #106 プロフィール編集ページの作成
- [fix] refs #106 設定画面のときはフッターを非表示にするように修正
- [fix] refs #107 アカウント削除ページの作成
- [Add] その他の設定ページのルートを作成

# レビューポイント

## 注意点
- あれば書く


## reviewee チェックシート
- [ ] 参考になる情報をチケット or PR に書くか、リンクした
- [ ] セルフレビューを実施した(flake8)
- [ ] カンバンを動かす
