### PR TITLE
ヘッダーメニューの表示変更&onScrollのバグを修正

### DIFF
--- a/src/src/components/molecules/ProfilePageMenu.vue
+++ b/src/src/components/molecules/ProfilePageMenu.vue
@@ -69,7 +69,7 @@ export default class ProfilePageMenu extends Vue {
 
 .active-menu:after
   content ""
-  background -webkit-linear-gradient(180deg, #B464A3 0%, 100%), #807DBA
+  background linear-gradient(#B464A3,#807DBA)
   display block
   height 5px
   width -webkit-fill-available

--- a/src/src/components/organisms/HeaderMenu.vue
+++ b/src/src/components/organisms/HeaderMenu.vue
@@ -1,11 +1,16 @@
 <template lang='pug'>
-div.body
-    .menu-wrapper
-        .header-menu(v-for='i in menuItems')
-            .menu-item(@click="goto(i.link)")
-                i.icon.column-icon(:class="i.icon" v-if="i.icon")
-                | {{ i.itemName }}
-                .sub-item(v-if="i.subItem") {{ i.subItem }}
+  div.body
+    div.menu-wrapper
+      div.header-menu
+        div.menu-item
+          span {{userName}}
+          .sub-item @{{userId}}
+        div.menu-item(v-if="!excluded.includes(routeName)" @click="goto(`/profile/${userId}`)")
+          sui-icon.column-icon(name="user")
+          span Profile
+        div.menu-item(v-for='i in menuItems' v-if="i.itemName !== 'Profile'" @click="goto(i.link)")
+          sui-icon.column-icon(:name="i.icon" v-if="i.icon")
+          span {{ i.itemName }}
 </template>
 
 <script lang='ts'>
@@ -13,20 +18,11 @@ import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
 
 @Component({})
 export default class HeaderMenu extends Vue {
+    private routeName: string | undefined = undefined;
+    private excluded: string[] = ['profile', 'questions'];
     @Prop({ type: String }) private userName!: string;
     @Prop({ type: String }) private userId!: string;
     private menuItems: any = [
-        {
-            itemName: this.userName,
-            subItem: this.userId,
-            link: null,
-            icon: null,
-        },
-        {
-            itemName: 'Profile',
-            link: `/profile/${this.userId}`,
-            icon: 'user',
-         },
         {
             itemName: '設定',
             link: '/settings',
@@ -54,9 +50,6 @@ export default class HeaderMenu extends Vue {
         }
     }
     private goto(link: string) {
-        if (link === null) {
-            return;
-        }
         if (link === 'logout') {
             this.$auth.logOut();
             return;
@@ -71,6 +64,7 @@ export default class HeaderMenu extends Vue {
     }
     private created() {
         window.addEventListener('click', this.closeModal);
+        this.routeName = this.$route.name;
     }
     private beforeDestroy() {
         window.removeEventListener('click', this.closeModal);
@@ -108,5 +102,6 @@ a:link, a:visited
             margin-right 10px
         .sub-item
             color #999
-            padding-top 5px
+            padding-top 4px
+            font-size 13px
 </style>

--- a/src/src/components/organisms/Impressions.vue
+++ b/src/src/components/organisms/Impressions.vue
@@ -77,7 +77,7 @@ export default class Impressions extends Vue {
   public isImpression: boolean = true;
   public userImpressions: object = [];
 
-  public mounted() {
+  private mounted() {
     this.watchScroll();
   }
 
@@ -87,7 +87,7 @@ export default class Impressions extends Vue {
   }
 
   @Emit()
-  public getMoreImpressions() {
+  private getMoreImpressions() {
     this.page++;
     this.$apollo.queries.userImpressions.fetchMore({
       variables: {
@@ -96,6 +96,7 @@ export default class Impressions extends Vue {
         size: pageSize,
       },
       updateQuery: (previousResult, { fetchMoreResult }) => {
+        if (!fetchMoreResult) { return previousResult; }
         const pre = previousResult.userImpressions;
         const result = fetchMoreResult.userImpressions;
         if (result.length < pageSize) {
@@ -109,8 +110,13 @@ export default class Impressions extends Vue {
   }
 
   @Emit()
-  public watchScroll() {
+  private watchScroll() {
     window.onscroll = () => {
+      /**
+       *  profileページに行った後はwatchScrollがマウントされているので
+       * 不要な部分でgetMoreImpressionsが作動してしまうことを防ぐ目的
+       */
+      if (this.$route.name !== 'profile') { return; }
       const scrollingPosition: number = document.documentElement.scrollTop + window.innerHeight;
       const bottomPosition: HTMLElement | null = document.getElementById('app');
       if (bottomPosition == null) { return; }
@@ -121,7 +127,7 @@ export default class Impressions extends Vue {
   }
 
   @Emit()
-  public toggleImpressionModal() {
+  private toggleImpressionModal() {
     this.showImpressionModal = false;
     this.$apollo.queries.userImpressions.setVariables(
       { name: this.$route.params.userName, page: 0, size: pageSize },


### PR DESCRIPTION
## 関連Issue
#117 

## 変更点
- [x] ヘッダーメニューのProfileをプロフィール画面では表示しないように修正
- [x] onScrollでの回答取得がprofile画面以外でも発生してしまうバグをfix

## reviewee チェックシート
- [x] 参考になる情報をチケット or PR に書くか、リンクした
- [ ] セルフレビューを実施した(flake8)
- [ ] カンバンを動かす
