### PR TITLE
[fix] フォント読み込みの最適化

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -6,11 +6,20 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>Montage</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons">
-    <link rel="preload" href="/css/footer.99f4b6ed.css" as="style" type="text/css" crossorigin>
+    <link rel="preload" as="font" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" crossorigin>
+    <link rel="preload" as="font" href="https://fonts.googleapis.com/css?family=Material+Icons" crossorigin>
+    <link rel="preload" href="/css/footer.edb6e44c.css" as="style" type="text/css" crossorigin>
     <link rel="preload" href="/css/home.da62f89a.css" as="style" type="text/css" crossorigin>
-    <link rel="preload" href="/css/header.ca3684b2.css" as="style" type="text/css" crossorigin>
+    <link rel="preload" href="/css/header.8ae1db47.css" as="style" type="text/css" crossorigin>
+    <style>
+    @font-face {
+      font-family: 'Roboto';
+      font-style: normal;
+      font-weight: 400;
+      src: local('Roboto'), local('Roboto-Regular'),
+           url('https://firstlayout.net/wp-content/themes/bariiito/fonts/roboto-v18-latin-regular.woff2') format('woff2');
+    }
+    </style>
   </head>
   <body>
     <noscript>

--- a/src/src/App.vue
+++ b/src/src/App.vue
@@ -55,7 +55,7 @@ export default {
 
 <style lang="stylus">
 body
-  font-family 'ＭＳ Ｐゴシック', 'MS PGothic', sans-serif !important
+  font-family 'Roboto', sans-serif
   background #F8F8F8 !important
   min-height 100vh
   margin 0


### PR DESCRIPTION
## 概要
Googleフォントをpreloadでレンダリングブロックしないようにする
参考: https://mogumogu-design.com/googlefont-yomikomi/
