### PR TITLE
Profileページのバグfix

### DIFF
--- a/src/src/components/molecules/CategoryLabels.vue
+++ b/src/src/components/molecules/CategoryLabels.vue
@@ -1,20 +1,31 @@
 <template lang='pug'>
     div.flex-category-box
       ul.flex-category-box-inline
-        sui-label.category-label(v-for='cat in categories', :key="cat.id", :style="{background: cat.color}")
-          router-link(:to="{ name: 'questions', params: { userName: username, categoryType: cat.link, categoryName: cat.category }}")
-            | {{ cat.category }}
+        sui-label.category-label(
+          v-for='cat in allCategories'
+          :key="cat.id"
+          :style="{background: '#F0EBD8'}")
+          router-link(
+            :to="{\
+               name: 'questions',\
+               params: { userName: username, categoryId: cat.id }}")
+            | {{ cat.name }}
 </template>
 <script lang='ts'>
 import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
+import { AllCategoriesQuery } from '../../constants/get_all-categories-query';
 
-@Component({})
+@Component({
+  apollo: {
+    allCategories: {
+      query: AllCategoriesQuery,
+      update: (data) => data.categories,
+    },
+  },
+})
 export default class CategoryLabels extends Vue {
   @Prop()
   public username!: string;
-
-  @Prop()
-  public categories!: object[];
 }
 </script>
 

--- a/src/src/components/molecules/ProfileImageTop.vue
+++ b/src/src/components/molecules/ProfileImageTop.vue
@@ -1,13 +1,11 @@
 <template lang='pug'>
   div
     div.overlay-area
-      lazy-component
-        sui-image.picture-area(:src="user.profileImgUrl" fluid alt='プロフィール画像')
+      sui-image.picture-area(:src="user.profileImgUrl" fluid alt='プロフィール画像')
       div.float-area
         div(style="width: 50%;")
           div.displayname {{user.displayName}}
           div.username.font-size__small @{{user.username}}
-        //- ProfileCardStats.font-size__small.follow-area(:stats="{following:  22, follower: 33}")
 </template>
 
 <script lang='ts'>

--- a/src/src/components/molecules/ProfilePageMenu.vue
+++ b/src/src/components/molecules/ProfilePageMenu.vue
@@ -3,8 +3,7 @@
     sui-menu(:widths='2' tabular labeled icon)
       sui-menu-item(
         :class="{'active-menu': isProfile}"
-        :active="isProfile"
-        @click="select(`Profile`)")
+        :active="isProfile")
         router-link.column-link(:to="{\
           name: 'profile',\
           params: { userName: username }\
@@ -13,8 +12,7 @@
           span プロフィール
       sui-menu-item(
         :class="{'active-menu': !isProfile}"
-        :active="!isProfile"
-        @click="select(`Questions`)")
+        :active="!isProfile")
         router-link.column-link(:to="{\
           name: 'questions',\
           params: {\
@@ -32,43 +30,28 @@ import { Component, Vue, Emit, Prop, Watch } from 'vue-property-decorator';
 @Component({})
 export default class ProfilePageMenu extends Vue {
   private isProfile: boolean | null = null;
-  private active: string | null = null;
 
   @Prop({ type: String })
   private username!: string;
 
+  @Prop({ type: String })
+  private whichPage!: string;
+
   private created() {
-    if (
-      this.$route.path.endsWith(this.username + '/')
-      || this.$route.path.endsWith(this.username)
-    ) {
+    this.isProfileHandler();
+  }
+
+  private isProfileHandler() {
+    if (this.whichPage === 'profile') {
       this.isProfile = true;
     } else {
       this.isProfile = false;
     }
   }
-  /**
-   * メニューをクリックすると、それぞれのメニュー名がselect()でセットされ、activeの値が変更される.
-   * activeが変更されると、watchで検知され、isProfileの値が変更される.
-   * メニューの下線はisActiveでisProfileの値を見てどちらのメニューにつくか決定される.
-   */
-  @Watch('active')
-  private onChangeMenuStatus() {
-    if (this.active === 'Profile') {
-      this.isProfile = true;
-    } else if (this.active === 'Questions') {
-      this.isProfile = false;
-    }
-  }
 
-  @Emit()
-  private isActive(name: string) {
-    this.isProfile = (this.active === name);
-  }
-
-  @Emit()
-  private select(name: string) {
-    this.active = name;
+  @Watch('whichPage')
+  private borderBottomHandler() {
+    this.isProfileHandler();
   }
 }
 </script>>

--- a/src/src/components/molecules/ProfilePageMenu.vue
+++ b/src/src/components/molecules/ProfilePageMenu.vue
@@ -19,8 +19,7 @@
           name: 'questions',\
           params: {\
             userName: username,\
-            categoryType: 'you',\
-            categoryName: 'あなたについて'\
+            categoryId: 1,\
           }\
         }")
           i.question.circle.icon

--- a/src/src/components/molecules/QuestionCard.vue
+++ b/src/src/components/molecules/QuestionCard.vue
@@ -5,7 +5,12 @@
         lazy-component
           sui-image.montage-icon-for-card(src='https://res.cloudinary.com/hugc8unfj/image/upload/v1568433502/public/montage-icon-Circle.jpg', shape='circular', size='tiny', centered='')
         sui-header-content.font-size__medium.content-height {{question.about}}
-      Button.questions-card-bottom(content="回答する" :placeholder="question.about" :questionId="question.id" @onModalClick="$listeners['onModal']") </template>
+      Button.questions-card-bottom(
+        content="回答する"
+        :placeholder="question.about"
+        :questionId="question.id"
+        @onModalClick="$listeners['onModal']")
+</template>
 
 <script lang='ts' scoped>
 import { Component, Vue, Emit, Prop } from 'vue-property-decorator';

--- a/src/src/components/organisms/Impressions.vue
+++ b/src/src/components/organisms/Impressions.vue
@@ -4,12 +4,20 @@
       div(v-for="imp in userImpressions").feed-content
         sui-card.raised.qa-card
           sui-card-content
-            sui-card-header(style='margin-bottom: 10px;')| Q. {{imp.question.about}}
+            sui-card-header(
+              style='margin-bottom: 10px;')| Q. {{imp.question.about}}
             div(style="display: flex;")
-              ProfileRoundImage.user-icon(v-if="user" :url="user.profileImgUrl", :size="impressionImgSize")
-              sui-label.baloon(pointing='left', size='medium' style="background: #f5f5f5")
+              ProfileRoundImage.user-icon(
+                v-if="user"
+                :url="user.profileImgUrl"
+                :size="impressionImgSize")
+              sui-label.baloon(
+                pointing='left'
+                size='medium'
+                style="background: #f5f5f5")
                 p(style="color: #555555") {{imp.content}}
-          ReactionIconGroup(@modalToggle="modalImpressionToggle(imp.question.about, imp.question.id)")
+          ReactionIconGroup(
+            @modalToggle="modalImpressionToggle(imp.question.about, imp.question.id)")
         ModalForm(v-if="showImpressionModal",
                   :placeholder="placeholder",
                   :selectedQuestionId="selectedQuestionId",

--- a/src/src/components/organisms/Questions.vue
+++ b/src/src/components/organisms/Questions.vue
@@ -55,6 +55,7 @@ const QuestionsPageSize: number = 10;
           };
         }
       },
+      update: ( data ) => data.getCategoryQuestions,
     },
   },
 })

--- a/src/src/components/organisms/Questions.vue
+++ b/src/src/components/organisms/Questions.vue
@@ -55,7 +55,14 @@ const QuestionsPageSize: number = 10;
           };
         }
       },
-      update: ( data ) => data.getCategoryQuestions,
+      result({ data }: any, loading: any, networkStatus: any) {
+        if (data.categoryQuestions === null) {
+          console.info('There is no questions of the category.');
+        }
+      },
+      error(error) {
+        console.error(error);
+      },
     },
   },
 })

--- a/src/src/components/organisms/Questions.vue
+++ b/src/src/components/organisms/Questions.vue
@@ -1,10 +1,15 @@
 <template lang="pug">
   div
-    CategoryLabels(:categories="categories" :username="user.username")
+    CategoryLabels(:username="user.username")
     GrayCenterText
     p(v-for="question in categoryQuestions")
       QuestionCard(:question="question" @onModal="modalQuestionToggle")
-    ModalForm(v-if="showQuestionModal" :placeholder="placeholder" :selectedQuestionId="selectedQuestionId" :isImpression="isImpression" @offModal="modalQuestionToggle")
+    ModalForm(
+      v-if="showQuestionModal"
+      :placeholder="placeholder"
+      :selectedQuestionId="selectedQuestionId"
+      :isImpression="isImpression"
+      @offModal="modalQuestionToggle")
 </template>
 
 <script lang="ts">
@@ -44,7 +49,7 @@ const QuestionsPageSize: number = 10;
         if (this.$route && this.$route.params) {
           return {
             userId: this.user.id,
-            categoryName: this.$route.params.categoryName,
+            categoryId: this.$route.params.categoryId,
             page: 0,
             size: QuestionsPageSize,
           };
@@ -57,12 +62,6 @@ export default class Questions extends Vue {
 
   @Prop()
   public user!: object;
-
-  public categories: object[] = [
-      { category: 'あなたについて', link: 'you', color: '#F0EBD8'},
-      { category: 'love', link: 'love', color: '#F0EBD8'},
-      { category: '趣味', link: 'hobby', color: '#F0EBD8'},
-  ];
   public page: number = 0;
   public loading: number = 0;
   public loadEnable: boolean = true;

--- a/src/src/components/pages/Profile.vue
+++ b/src/src/components/pages/Profile.vue
@@ -3,7 +3,7 @@
     //- userが読み込まれるまでv-ifで非表示しないとundefined property
     div(v-if="user")
       ProfileImageTop(:user="user")
-      ProfilePageMenu(:username="user.username")
+      ProfilePageMenu(:username="user.username" :whichPage="this.$route.name")
       router-view(:user="user")
     div(v-else)
       Loading

--- a/src/src/constants/category-questions-query.ts
+++ b/src/src/constants/category-questions-query.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const categoryQuestionsQuery: any = gql`
-query getCategoryQuestions(
+query categoryQuestions(
   $userId: Int,
   $categoryId: Int,
   $page: Int,

--- a/src/src/constants/category-questions-query.ts
+++ b/src/src/constants/category-questions-query.ts
@@ -3,12 +3,12 @@ import gql from 'graphql-tag';
 export const categoryQuestionsQuery: any = gql`
 query getCategoryQuestions(
   $userId: Int,
-  $categoryName: String,
+  $categoryId: Int,
   $page: Int,
   $size: Int){
   categoryQuestions(
     userId: $userId,
-    categoryName: $categoryName,
+    categoryId: $categoryId,
     page: $page,
     size: $size){
     id

--- a/src/src/constants/get_all-categories-query.ts
+++ b/src/src/constants/get_all-categories-query.ts
@@ -1,0 +1,10 @@
+import gql from 'graphql-tag';
+
+export const AllCategoriesQuery: any = gql`
+query allCategories {
+  categories{
+    id
+    name
+    description
+  }
+}`;

--- a/src/src/router.ts
+++ b/src/src/router.ts
@@ -116,7 +116,7 @@ const router = new Router({
           component: Impressions,
         },
         {
-          path: 'q/:categoryName',
+          path: 'category/:categoryId',
           name: 'questions',
           component: Questions,
         },


### PR DESCRIPTION
## 変更点
[fix] カテゴリをクエリで取得するように修正
[fix] templateをリファクタリング
[fix] lazy-componentによってTOP画像が表示されなくなっていたバグを修正
[fix] カテゴリ毎の質問を取得するときにクエリ名と取得する変数名が異なるバグをupdateで解決
[fix] QuestionsにしてからHOMEアイコンで自分のページに戻ったときにボーダーが変わらない
