### PR TITLE
質問と回答の投稿時の表示バグの修正＆vue-headでタイトル表示＆ログインボタンのデザイン修正

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -17007,6 +17007,11 @@
         "loose-envify": "^1.2.0"
       }
     },
+    "vue-head": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vue-head/-/vue-head-2.2.0.tgz",
+      "integrity": "sha512-Oss1gakOSPQ4e/XZ0yM7yolnhSDvfDYZbM6CDD3xkCpAyPfTR+Bv3tabgtKE41gHr5GzC/NJh1EwQSu7o05XRw=="
+    },
     "vue-hot-reload-api": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -38,6 +38,7 @@
     "vue": "^2.6.10",
     "vue-apollo": "^3.0.2",
     "vue-class-component": "^6.0.0",
+    "vue-head": "^2.2.0",
     "vue-lazyload": "^1.3.3",
     "vue-router": "^3.1.2",
     "vue-semantic-modal": "^2.1.0",

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#ddd">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title>Montage</title>
+    <title>montage.bio</title>
     <link rel="preload" as="font" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" crossorigin>
     <link rel="preload" as="font" href="https://fonts.googleapis.com/css?family=Material+Icons" crossorigin>
     <link rel="preload" href="/css/footer.edb6e44c.css" as="style" type="text/css" crossorigin>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="theme-color" content="#ddd">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>Montage</title>

--- a/src/src/components/atoms/DimButton.vue
+++ b/src/src/components/atoms/DimButton.vue
@@ -1,5 +1,11 @@
 <template lang='pug'>
-  button.dimmer(@click="dimmerLogin") {{ label }}
+  sui-button(
+    circular
+    social="twitter"
+    content="Twitterではじめる"
+    icon="twitter"
+    @click="dimmerLogin"
+    style="margin: 16px 0; background: rgba(0, 0, 0, 0.27);")
 </template>
 
 <script lang='ts'>

--- a/src/src/components/organisms/AccountSettings.vue
+++ b/src/src/components/organisms/AccountSettings.vue
@@ -25,6 +25,18 @@ import { Component, Vue, Emit, Prop, Watch } from 'vue-property-decorator';
 import { userQuery } from '../../constants/user_query';
 
 @Component({
+  head: {
+    title: {
+      inner: 'settings',
+      separator: '/',
+    },
+    meta: [
+      {
+         name: 'description',
+         content: 'ユーザの設定ページ',
+      },
+    ],
+  },
   apollo: {
     $loadingKey: 'loading',
     user: {
@@ -48,7 +60,6 @@ import { userQuery } from '../../constants/user_query';
   },
 })
 export default class AccountSettings extends Vue {
-
   private get skipQuery() {
     /**
      * attrsに値が設定されたらスキップを解除する.

--- a/src/src/components/organisms/DeactivateForm.vue
+++ b/src/src/components/organisms/DeactivateForm.vue
@@ -26,6 +26,18 @@ const Button = () => import(
   components: {
     Button,
   },
+  head: {
+    title: {
+      inner: '退会',
+      separator: '/',
+    },
+    meta: [
+      {
+         name: 'description',
+         content: 'ユーザが退会をするためのページ',
+      },
+    ],
+  },
 })
 export default class DeactivateForm extends Vue {
   private listItems: string[] = [

--- a/src/src/components/organisms/Faq.vue
+++ b/src/src/components/organisms/Faq.vue
@@ -6,7 +6,20 @@
 <script lang='ts'>
 import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
 
-@Component({})
+@Component({
+  head: {
+    title: {
+      inner: 'よくある質問',
+      separator: '/',
+    },
+    meta: [
+      {
+         name: 'description',
+         content: 'サービスについてのよくある質問を記載したページ',
+      },
+    ],
+  },
+})
 export default class Faq extends Vue {
 
 }

--- a/src/src/components/organisms/Impressions.vue
+++ b/src/src/components/organisms/Impressions.vue
@@ -79,6 +79,7 @@ const pageSize: any = 10;
           };
         }
       },
+      fetchPolicy: 'cache-and-network',
     },
   },
 })

--- a/src/src/components/organisms/ModalForm.vue
+++ b/src/src/components/organisms/ModalForm.vue
@@ -26,7 +26,6 @@
 import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
 import router from '../../router';
 import { CreateImpressionMutation } from '../../constants/create_impression_query';
-import { impressionQuery } from '../../constants/get-user-impression-query';
 
 const ConfirmButton = () => import(
   /* webpackChunkName: "confirm-button" */
@@ -81,6 +80,8 @@ export default class ModalForm extends Vue {
         } else {
           console.log('fail');
         }
+      }).catch((error) => {
+        console.log(error);
       });
   }
 }

--- a/src/src/components/organisms/Questions.vue
+++ b/src/src/components/organisms/Questions.vue
@@ -56,13 +56,14 @@ const QuestionsPageSize: number = 10;
         }
       },
       result({ data }: any, loading: any, networkStatus: any) {
-        if (data.categoryQuestions === null) {
+        if (!data.categoryQuestions) {
           console.info('There is no questions of the category.');
         }
       },
       error(error) {
         console.error(error);
       },
+      fetchPolicy: 'no-cache',
     },
   },
 })

--- a/src/src/components/pages/About.vue
+++ b/src/src/components/pages/About.vue
@@ -31,7 +31,20 @@
 <script lang="ts">
 import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
 
-@Component({})
+@Component({
+  head: {
+    title: {
+      inner: 'このサイトについて',
+      separator: '/',
+    },
+    meta: [
+      {
+         name: 'description',
+         content: 'montage.bio はユーモア持ったユーザのための匿名プロフィールSNSです。',
+      },
+    ],
+  },
+})
 export default class About extends Vue {
 }
 </script>

--- a/src/src/components/pages/Faq.vue
+++ b/src/src/components/pages/Faq.vue
@@ -41,6 +41,18 @@ const FeatureColumn = () => import(
   components: {
     FeatureColumn,
   },
+  head: {
+    title: {
+      inner: 'よくある質問',
+      separator: '/',
+    },
+    meta: [
+      {
+         name: 'description',
+         content: 'montage.bioの利用規約。',
+      },
+    ],
+  },
 })
 export default class Faq extends Vue {
 }

--- a/src/src/components/pages/Home.vue
+++ b/src/src/components/pages/Home.vue
@@ -10,7 +10,7 @@
         router-link(to="/privacy_policy") プライバシーポリシー
       div
         i.angle.double.down.icon(style="color: #ffffff;")
-      h5.catch_copy(is='sui-header') Montageとは?
+      h5.catch_copy(is='sui-header') montage.bioとは?
       FeatureColumnGroup.flex-column
       DimButton(label='はじめる')
 </template>
@@ -31,8 +31,21 @@ const FeatureColumnGroup = () => import(
     DimButton,
     FeatureColumnGroup,
   },
+  head: {
+    title: {
+      inner: 'ホーム',
+      separator: '/',
+    },
+    meta: [
+      {
+         name: 'description',
+         content: 'montage.bioのメインページ。',
+      },
+    ],
+  },
 })
-export default class Home extends Vue {}
+export default class Home extends Vue {
+}
 </script>
 
 <style lang="stylus" scoped>

--- a/src/src/components/pages/Home.vue
+++ b/src/src/components/pages/Home.vue
@@ -2,17 +2,19 @@
   div.wrapper
     div.content-wrapper(is='sui-container' textAlign='center')
       img.logo(src='@/assets/icon.svg')
-      h5.catch_copy(is='sui-header') 友達も、好きな人も、自由にイジろう
-      DimButton(label='はじめる')
+      h5.catch-copy(is='sui-header') 友達も、好きな人も、自由にイジろう
+      DimButton(label='Twitterではじめる')
+      div.twitter-annotation ※勝手にツイートやフォローをすることはありません。
       div.term-policy-block
         router-link(to="/terms/") 利用規約
         span /
         router-link(to="/privacy_policy") プライバシーポリシー
       div
         i.angle.double.down.icon(style="color: #ffffff;")
-      h5.catch_copy(is='sui-header') montage.bioとは?
+      h5.catch-copy(is='sui-header') montage.bioとは?
       FeatureColumnGroup.flex-column
-      DimButton(label='はじめる')
+      DimButton(label='Twitterではじめる')
+      div.twitter-annotation ※勝手にツイートやフォローをすることはありません。
 </template>
 
 <script lang='ts'>
@@ -62,10 +64,15 @@ export default class Home extends Vue {
   height auto
   margin-left 20px
 
-.catch_copy
+.catch-copy
   margin 4px 0px !important
   color #FFFFFF !important
   font-weight unset !important
+
+.twitter-annotation
+  padding 0 0 20px 0 !important
+  font-size 10px !important
+  color #FFFFFF !important
 
 .term-policy-block
   text-align center

--- a/src/src/components/pages/NotFound.vue
+++ b/src/src/components/pages/NotFound.vue
@@ -16,7 +16,20 @@
 <script lang="ts">
 import { Component, Vue, Emit, Prop } from 'vue-property-decorator';
 
-@Component({})
+@Component({
+  head: {
+    title: {
+      inner: 'NOT FOUND',
+      separator: '/',
+    },
+    meta: [
+      {
+         name: 'description',
+         content: 'montage.bioのNOT FOUNDページ。',
+      },
+    ],
+  },
+})
 export default class NotFound extends Vue {
 }
 </script>

--- a/src/src/components/pages/PrivacyTemplate.vue
+++ b/src/src/components/pages/PrivacyTemplate.vue
@@ -2,7 +2,7 @@
   div
     div(is='sui-container')
       TopMenu(isTerms=false)
-      h2.terms-title-style プライバシーポリシー
+      h2.terms-title-style サービス利用規約
       p.privacy-preface-style Montage運営者(以下「運営者」といいます)は、お客様の個人情報保護の重要性について認識し、個人情報の保護に関する法律(以下「個人情報保護法」といいます)を遵守すると共に、以下のプライバシーポリシー(以下「本プライバシーポリシー」といいます)に従い、「Montage」の名前で運営者から提供されるサービス(以下「本サービス」といいます)の利用にあたってお客様から取得する個人情報の適切な取扱い及び保護に努めます。
       div(v-for="block in blocks")
         TermsBlock
@@ -32,6 +32,18 @@ const TopMenu = () => import(
   components: {
     TopMenu,
     TermsBlock,
+  },
+  head: {
+    title: {
+      inner: 'プライバシーポリシー',
+      separator: '/',
+    },
+    meta: [
+      {
+         name: 'description',
+         content: 'montage.bioのプライバシーポリシーページ。',
+      },
+    ],
   },
 })
 export default class TermsTemplate extends Vue {

--- a/src/src/components/pages/Profile.vue
+++ b/src/src/components/pages/Profile.vue
@@ -37,6 +37,20 @@ const Loading = () => import(
     ProfilePageMenu,
     Loading,
   },
+  head: {
+    title() {
+      return {
+        inner: this.$route.params.userName + 'さん',
+        separator: '/',
+      };
+    },
+    meta: [
+      {
+         name: 'description',
+         content: '質問一覧、、回答一覧を表示するプロフィールページ',
+      },
+    ],
+  },
   apollo: {
     $loadingKey: 'loading',
     user: {

--- a/src/src/components/pages/TermsTemplate.vue
+++ b/src/src/components/pages/TermsTemplate.vue
@@ -33,8 +33,21 @@ const TopMenu = () => import(
     TopMenu,
     TermsBlock,
   },
+  head: {
+    title: {
+      inner: 'montage.bioサービス利用規約',
+      separator: '/',
+    },
+    meta: [
+      {
+         name: 'description',
+         content: 'montage.bioの利用規約ページ。',
+      },
+    ],
+  },
 })
 export default class TermsTemplate extends Vue {
+  private title: string = '';
   private blocks: any = [
       {
         title: '第1条（規約への同意）',

--- a/src/src/main.ts
+++ b/src/src/main.ts
@@ -13,6 +13,7 @@ import '../semantic/dist/semantic.css';
 import SuiVue from 'semantic-ui-vue';
 import AuthPlugin from './plugins/auth';
 import VueLazyload from 'vue-lazyload';
+import VueHead from 'vue-head';
 
 Vue.config.productionTip = false;
 const errorLink = onError(({ graphQLErrors, networkError }) => {
@@ -49,6 +50,7 @@ const apolloProvider = createProvider({
 Vue.use(SuiVue);
 Vue.use(AuthPlugin);
 Vue.use(VueLazyload, { lazyComponent: true});
+Vue.use(VueHead);
 
 new Vue({
   router,


### PR DESCRIPTION
## 変更点
[fix] mutation後にキャッシュを更新するためにポリシーを設定
[fix] 不要なimport削除＆例外の捕捉
[Add] ヘッダーに色を追加
[fix] タイトルとdesctiptionのメタ情報をvue-headで追加
[fix] ログインボタンをTwitterログインとわかるように修正＆注意事項の追加

